### PR TITLE
Support for normalizr-immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/dehbmarques/denormalizr-immutable.git"
   },
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --recursive",
+    "test": "mocha --compilers --harmony-proxies js:babel-core/register --recursive",
     "test:watch": "npm run test -- --watch",
     "prebuild": "rimraf dist lib",
     "build": "webpack && babel src --out-dir lib",
@@ -40,6 +40,7 @@
   "dependencies": {
     "immutable": "^3.7.6",
     "lodash": "^4.6.1",
-    "normalizr": "^2.0.0"
+    "normalizr": "^2.0.0",
+    "normalizr-immutable": "0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/dehbmarques/denormalizr-immutable.git"
   },
   "scripts": {
-    "test": "mocha --compilers --harmony-proxies js:babel-core/register --recursive",
+    "test": "mocha --compilers js:babel-core/register --recursive",
     "test:watch": "npm run test -- --watch",
     "prebuild": "rimraf dist lib",
     "build": "webpack && babel src --out-dir lib",


### PR DESCRIPTION
This commit adds support for objects normalized with [normalizr-immutable](https://github.com/mschipperheyn/normalizr-immutable)

- Works with entities defined both as Records, and Maps when normalized with the option `{ useMapsForEntityObjects: true } `
- Tests included

(The package.json diff is down to Mocha requiring the `--harmony-proxies` flag to work on my system, fixed in the second commit as I forgot to remove it)